### PR TITLE
Stop rendering at full width

### DIFF
--- a/big.html
+++ b/big.html
@@ -97,7 +97,7 @@ draw_column = function(){
   }
   
   // Next column
-  requestAnimationFrame(draw_column);
+  if (x < c.width) requestAnimationFrame(draw_column);
 }
 
 // Click on the canvas
@@ -126,6 +126,7 @@ c.onclick = function(e){
   
   // Reset column counter
   x = 0;
+  draw_column();
 }
 
 // Start drawing


### PR DESCRIPTION
I've noticed that `draw_column` runs infinitely. I've stopped it at the edge of the canvas, and restarted it on click. Behaviour should seem the same. Adding a console log inside `draw_column` shows the difference.